### PR TITLE
Improved country option label

### DIFF
--- a/admin/src/components/index.js
+++ b/admin/src/components/index.js
@@ -18,7 +18,7 @@ const InternationalInput = (props) => {
 const InputCountry = (props) => {
   const locale = currentLanguage in countries ? countries[currentLanguage] : countries.en;
   const options = Object.entries(locale.countries).map((country) => ({
-    label: country[1],
+    label: Array.isArray(country[1]) ? country[1][0] : country[1],
     value: Array.isArray(country[0]) ? country[0][0] : country[0]
   }));
 


### PR DESCRIPTION
This PR takes into account [multiple country names](https://github.com/michaelwittig/node-i18n-iso-countries/blob/master/langs/en.json#L226) which `i18n-iso-countries` now provides for some countries, for example:

```json
{
    "GB": ["United Kingdom", "UK", "Great Britain"],
    "US": ["United States of America", "USA"],
}
```

`strapi-plugin-international-fields` currently joins the names, which is incorrect:

![country select screenshot](https://i.imgur.com/CLzDbfa.png)